### PR TITLE
no simplejson needed

### DIFF
--- a/mixpanel/tasks.py
+++ b/mixpanel/tasks.py
@@ -1,10 +1,11 @@
 import httplib
 import urllib
 import base64
-import simplejson
 import urlparse
 import logging
 import socket
+
+from django.utils import simplejson
 
 from celery.task import Task
 from celery.registry import tasks

--- a/mixpanel/test/test_tasks.py
+++ b/mixpanel/test/test_tasks.py
@@ -1,8 +1,9 @@
 import unittest
 import base64
-import simplejson
 import urllib
 import logging
+
+from django.utils import simplejson
 
 from celery.exceptions import RetryTaskError
 


### PR DESCRIPTION
Hello!

Since there is simplejson module in a new version of Python, you don't need to install simplejson anymore.

There is a special module in Django which just replaces itself by standard json in new Pythons, and runs as is in the old ones. I used it.
