### PR TITLE
removing dependence on DJANGO_SETTINGS_MODULE

### DIFF
--- a/mixpanel/conf/settings.py
+++ b/mixpanel/conf/settings.py
@@ -1,6 +1,10 @@
 """Default configuration values and documentation"""
 
 from django.conf import settings
+import os
+
+if os.getenv('DJANGO_SETTINGS_MODULE', None) is None:
+    settings.configure()
 
 """
 .. data:: MIXPANEL_API_TOKEN


### PR DESCRIPTION
fixing an issue we ran into - we don't use django at all, so we didn't like the the dependence on the DJANGO_SETTINGS_MODULE environment variable being present. let me know what you think - thanks.

safety check to ensure django settings are still read (if only as blank) on environments without DJANGO_SETTINGS_MODULE set
