### PR TITLE
Fix for Celery >= 3.0.

### DIFF
--- a/mixpanel/tasks.py
+++ b/mixpanel/tasks.py
@@ -40,7 +40,7 @@ class EventTracker(Task):
         """
         l = self.get_logger(**kwargs)
         l.info("Recording event: <%s>" % event_name)
-        if l.logger.getEffectiveLevel() == logging.DEBUG:
+        if l.getEffectiveLevel() == logging.DEBUG:
             httplib.HTTPConnection.debuglevel = 1
 
         is_test = self._is_test(test)


### PR DESCRIPTION
Just needed to remove the attribute lookup `l.logger` to get this to work with Celery >= 3.0 to fix Issue #7.

Signed-off-by: Kevin Stone kevinastone@gmail.com
