### PR TITLE
The People event is $add, not $increment.

### DIFF
--- a/mixpanel/tasks.py
+++ b/mixpanel/tasks.py
@@ -181,7 +181,7 @@ class PeopleTracker(EventTracker):
     endpoint = mp_settings.MIXPANEL_PEOPLE_ENDPOINT
     event_map = {
         'set': '$set',
-        'add': '$increment',
+        'add': '$add',
         'track_charge': '$append',
     }
 


### PR DESCRIPTION
Per the documentation at https://mixpanel.com/docs/people-analytics/people-http-specification-insert-data, the events that can be used with the People API are '$set', '$set_once', '$add', and '$append'. Currently `PeopleTracker` uses $increment instead of $add, and I verified that this does not work - MIxpanel rejects the request. Changing it to $add fixes it.

I've verified this doesn't break the tests in the "Celery-2.X" tox env; the tests in the other envs fail for me on master due to `celery.utils.eager_tasks` no longer existing.
