### PR TITLE
Add MIXPANEL_DISABLE setting.

### DIFF
--- a/mixpanel/conf/settings.py
+++ b/mixpanel/conf/settings.py
@@ -31,6 +31,14 @@ MIXPANEL_API_TOKEN = getattr(settings, 'MIXPANEL_API_TOKEN', None)
 MIXPANEL_RETRY_DELAY = getattr(settings, 'MIXPANEL_RETRY_DELAY', 60*5)
 
 """
+.. data:: MIXPANEL_DISABLE
+
+    Set to ``True`` to disable mixpanel-celery; no events will be sent to
+    Mixpanel.
+"""
+MIXPANEL_DISABLE = getattr(settings, 'MIXPANEL_DISABLE', False)
+
+"""
 .. data:: MIXPANEL_MAX_RETRIES
 
     Number of retry attempts to make before raising an exception.

--- a/mixpanel/tasks.py
+++ b/mixpanel/tasks.py
@@ -44,6 +44,10 @@ class EventTracker(Task):
         Mixpanel servers.
         """
         l = self.get_logger(**kwargs)
+        if mp_settings.MIXPANEL_DISABLE:
+            l.info("Mixpanel disabled; not recording event: <%s>" % event_name)
+            return False
+
         l.info("Recording event: <%s>" % event_name)
 
         # Celery 3.x changed the way the logger could be accessed

--- a/mixpanel/tests/test_tasks.py
+++ b/mixpanel/tests/test_tasks.py
@@ -30,6 +30,17 @@ class EventTrackerTest(unittest.TestCase):
         mp_settings.MIXPANEL_API_SERVER = 'api.mixpanel.com'
         mp_settings.MIXPANEL_TRACKING_ENDPOINT = '/track/'
         mp_settings.MIXPANEL_TEST_ONLY = True
+        mp_settings.MIXPANEL_DISABLE = False
+
+    def test_disable(self):
+        et = EventTracker()
+        mp_settings.MIXPANEL_DISABLE = True
+
+        def _fake_get_connection():
+            assert False, "Should bail out before trying to get a connection."
+        et._get_connection = _fake_get_connection
+
+        et('foo')
 
     def test_handle_properties_w_token(self):
         et = EventTracker()


### PR DESCRIPTION
I ended up only adding the check to the `run()` method, to simplify the implementation, and because I realized that in most cases where you'd set `MIXPANEL_DISABLE` to `True` (i.e. tests) you'll probably also be running with eager Celery tasks, in which case there won't be a task queued anyway.

I also didn't change the name of the `MIXPANEL_TEST_ONLY` setting in this PR; I figured that's a separate change.
