### PR TITLE
Add support for $ignore_time for PeopleTracker

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -206,6 +206,30 @@ the mixpanel distinct id of 1. To increment profile property values using the
     )
     result.wait()
 
+Since some tasks are done separate from user interaction when updating their
+associated Person in mixpanel, you can set the ``$ignore_time`` special
+property by setting ``'ignore_time'`` to ``True`` in the ``properties``
+dictionary:
+
+.. code-block:: python
+
+    from mixpanel.tasks import PeopleTracker
+
+    result = PeopleTracker.delay(
+        'set',
+        {
+            'distinct_id': 1,
+            'Plan': 'Premium',
+            'ignore_time': True,
+        },
+        token='YOUR_API_TOKEN',
+    )
+    result.wait()
+
+This bypasses the automatic re-setting of the "Last Seen" date property on the
+Person as described in `Mixpanel's People HTTP Specification
+<https://mixpanel.com/docs/people-analytics/people-http-specification-insert-data>`__.
+
 You can also track charges using the ``track_charge`` event:
 
 .. code-block:: python

--- a/mixpanel/tasks.py
+++ b/mixpanel/tasks.py
@@ -219,11 +219,14 @@ class PeopleTracker(EventTracker):
             '$token': properties['token'],
             '$distinct_id': properties['distinct_id'],
         }
+        if 'ignore_time' in properties:
+            params['$ignore_time'] = properties['ignore_time']
+
         if event == 'track_charge':
             time = properties.get('time', datetime.datetime.now().isoformat())
             transactions = dict(
                 (k, v) for (k, v) in properties.iteritems()
-                if not k in ('token', 'distinct_id', 'amount')
+                if not k in ('token', 'distinct_id', 'ignore_time', 'amount')
             )
 
             transactions['$time'] = time
@@ -235,7 +238,7 @@ class PeopleTracker(EventTracker):
             # rest for passing with $set and $increment
             params[mp_key] = dict(
                 (k, v) for (k, v) in properties.iteritems()
-                if not k in ('token', 'distinct_id')
+                if not k in ('token', 'distinct_id', 'ignore_time')
             )
 
         return self._encode_params(params, is_test)

--- a/mixpanel/tests/test_tasks.py
+++ b/mixpanel/tests/test_tasks.py
@@ -121,6 +121,31 @@ class EventTrackerTest(unittest.TestCase):
 
         self.assertEqual(expected_params, parsed)
 
+    def test_build_people_track_ignore_time(self):
+        et = PeopleTracker()
+        event = 'set'
+        is_test = 1
+        properties = {'stuff': 'thing', 'blue': 'green',
+                      'distinct_id': 'test_id', 'token': 'testtoken',
+                      'ignore_time': True}
+
+        expected = {
+            '$distinct_id': 'test_id',
+            '$ignore_time': True,
+            '$set': {
+                'stuff': 'thing',
+                'blue': 'green',
+            },
+            '$token': 'testtoken',
+        }
+        url_params = et._build_params(event, properties, is_test)
+        expected_params = urllib.urlencode({
+            'data': base64.b64encode(simplejson.dumps(expected)),
+            'test': is_test,
+        })
+
+        self.assertEqual(expected_params, url_params)
+
     def test_build_people_set_params(self):
         et = PeopleTracker()
         event = 'set'


### PR DESCRIPTION
This feature allows the user to set the '$ignore_time' parameter in the
PeopleTracker per the [People HTTP Specification of the Mixpanel REST
API](https://mixpanel.com/docs/people-analytics/people-http-specification-insert-data). The user simply includes 'ignore_time' as True/False in their
properties dictionary and it gets converted to '$ignore_time' and
stripped from the properties dictionary. Included is a test and
documentation for this new functionality.

I wasn't sure if the user should use `ignore_time` or `$ignore_time` in their properties dictionary, so I just erred on the side of consistency and did it without the `$`.

Also, the Django 1.3 tests failed for me when running tox but they failed before the changes anyways.
