### PR TITLE
Change MIXPANEL_TEST_ONLY to MIXPANEL_TEST_PRIORITY.

### DIFF
--- a/mixpanel/conf/settings.py
+++ b/mixpanel/conf/settings.py
@@ -107,9 +107,11 @@ MIXPANEL_FUNNEL_EVENT_ID = getattr(settings, 'MIXPANEL_FUNNEL_EVENT_ID',
                                'mp_funnel')
 
 """
-.. data:: MIXPANEL_TEST_ONLY
+.. data:: MIXPANEL_TEST_PRIORITY
 
     If this value is True, then events will be sent to Mixpanel with the property
-    test = 1 so that no events will actually be logged.
+    test = 1 which uses a special high-priority queue.
+
+    http://blog.mixpanel.com/2010/04/22/a-way-to-ease-your-integration-with-mixpanel-while-were-working/
 """
-MIXPANEL_TEST_ONLY = getattr(settings, 'MIXPANEL_TEST_ONLY', False)
+MIXPANEL_TEST_PRIORITY = getattr(settings, 'MIXPANEL_TEST_PRIORITY', False)

--- a/mixpanel/tests/test_tasks.py
+++ b/mixpanel/tests/test_tasks.py
@@ -29,7 +29,7 @@ class EventTrackerTest(unittest.TestCase):
         mp_settings.MIXPANEL_API_TOKEN = 'testtesttest'
         mp_settings.MIXPANEL_API_SERVER = 'api.mixpanel.com'
         mp_settings.MIXPANEL_TRACKING_ENDPOINT = '/track/'
-        mp_settings.MIXPANEL_TEST_ONLY = True
+        mp_settings.MIXPANEL_TEST_PRIORITY = True
         mp_settings.MIXPANEL_DISABLE = False
 
     def test_disable(self):
@@ -78,7 +78,7 @@ class EventTrackerTest(unittest.TestCase):
         self.assertEqual(et._is_test(False), 0)
         self.assertEqual(et._is_test(True), 1)
 
-        mp_settings.MIXPANEL_TEST_ONLY = False
+        mp_settings.MIXPANEL_TEST_PRIORITY = False
         self.assertEqual(et._is_test(None), 0)
         self.assertEqual(et._is_test(False), 0)
         self.assertEqual(et._is_test(True), 1)
@@ -207,7 +207,7 @@ class BrokenRequestsTest(unittest.TestCase):
 
     def setUp(self):
         mp_settings.MIXPANEL_API_TOKEN = 'testtesttest'
-        mp_settings.MIXPANEL_TEST_ONLY = True
+        mp_settings.MIXPANEL_TEST_PRIORITY = True
         mp_settings.MIXPANEL_API_SERVER = 'api.mixpanel.com'
         mp_settings.MIXPANEL_TRACKING_ENDPOINT = '/track/'
         EventTracker.endpoint = mp_settings.MIXPANEL_TRACKING_ENDPOINT
@@ -236,7 +236,7 @@ class FunnelEventTrackerTest(unittest.TestCase):
         mp_settings.MIXPANEL_API_TOKEN = 'testtesttest'
         mp_settings.MIXPANEL_API_SERVER = 'api.mixpanel.com'
         mp_settings.MIXPANEL_TRACKING_ENDPOINT = '/track/'
-        mp_settings.MIXPANEL_TEST_ONLY = True
+        mp_settings.MIXPANEL_TEST_PRIORITY = True
 
     def test_afp_validation(self):
         fet = FunnelEventTracker()


### PR DESCRIPTION
Mixpanel changed the meaning of the test flag in 2010, see 
http://blog.mixpanel.com/2010/04/22/a-way-to-ease-your-integration-with-mixpanel-while-were-working/

It doesn't make sense to keep calling our setting MIXPANEL_TEST_ONLY, but the
flag might still be useful, so keep it around as MIXPANEL_TEST_PRIORITY and
update the various documentation bits.
