### PR TITLE
All events are being reported as not logged by mixpanel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.egg
 __pycache__
 *.egg-info
+
+build/
+dist/

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -1,6 +1,6 @@
 """Asynchronous event tracking for Mixpanel"""
 
-VERSION = (0, 9, 0, '')
+VERSION = (0, 10, 0, '')
 
 __version__ = ".".join(map(str, VERSION[:-1]))
 __release__ = ".".join(map(str, VERSION))

--- a/mixpanel/tasks.py
+++ b/mixpanel/tasks.py
@@ -144,7 +144,7 @@ class EventTracker(Task):
 
         # Successful requests will generate a log
         response_data = response.read()
-        if response_data != '1':
+        if response_data != b'1':
             return False
 
         return True

--- a/mixpanel/tests/test_tasks.py
+++ b/mixpanel/tests/test_tasks.py
@@ -53,7 +53,7 @@ class TasksTestCase(unittest.TestCase):
             reason = 'OK'
 
             def read(*args, **kwargs):
-                return '1'
+                return b'1'
         response = Response()
         self.response = response
 


### PR DESCRIPTION
This is happening because:

```python
        response_data = response.read()
        if response_data != '1':
            return False
```

`response_date` in the success case is actually `b'1'`. So that check fails in python3. Always