### PR TITLE
`exception.message` is no longer a thing

### DIFF
--- a/mixpanel/tasks.py
+++ b/mixpanel/tasks.py
@@ -132,7 +132,7 @@ class EventTracker(Task):
         except socket.error:
             raise self.FailedEventRequest(
                 "The tracking request failed with a socket error. "
-                "Message: [%s]" % sys.exc_info()[1].message
+                "Message: [%s]" % str(sys.exc_info()[1])
             )
 
         if response.status != 200 or response.reason != 'OK':

--- a/mixpanel/tests/test_tasks.py
+++ b/mixpanel/tests/test_tasks.py
@@ -224,6 +224,20 @@ class EventTrackerTest(TasksTestCase):
             'properties': {'token': 'testtesttest'}
         })
 
+    def test_socket_error_replaced_with_failed_event_request(self):
+        class FakeConnection(object):
+            def request(self, *args, **kwargs):
+                pass
+
+            def getresponse(self):
+                raise socket.error('BOOM')
+
+        et = EventTracker()
+
+        fake_connection = FakeConnection()
+        with self.assertRaises(EventTracker.FailedEventRequest):
+            et._send_request(fake_connection, {})
+
 
 class PeopleTrackerTest(TasksTestCase):
     @patch('mixpanel.tasks.datetime.datetime', FakeDateTime)


### PR DESCRIPTION
In `EventTracker._send_request` we are catching a socket error and re-raising a custom exception as part of that process, we are getting the string message of the socket error. This no longer works in python3.